### PR TITLE
Nested relationships for Select

### DIFF
--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -433,12 +433,6 @@ class Select extends Field
 
             $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getRelationshipTitleColumnName());
 
-            if ($callback) {
-                $relationshipQuery = $component->evaluate($callback, [
-                    'query' => $relationshipQuery,
-                ]);
-            }
-
             $search = strtolower($search);
 
             /** @var Connection $databaseConnection */
@@ -449,9 +443,17 @@ class Select extends Field
                 default => 'like',
             };
 
-            $relationshipQuery = $relationshipQuery
-                ->where($component->getRelationshipTitleColumnName(), $searchOperator, "%{$search}%")
-                ->limit(50);
+            if ($callback) {
+                $relationshipQuery = $component->evaluate($callback, [
+                    'query' => $relationshipQuery,
+                    'search' => $search,
+                    'searchOperator' => $searchOperator
+                ]);
+            } else {
+                $relationshipQuery = $relationshipQuery
+                    ->where($component->getRelationshipTitleColumnName(), $searchOperator, "%{$search}%")
+                    ->limit(50);
+            }
 
             $keyName = $component->isMultiple() ? $relationship->getRelatedKeyName() : $relationship->getOwnerKeyName();
 
@@ -465,7 +467,9 @@ class Select extends Field
             }
 
             return $relationshipQuery
+                ->get()
                 ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->sortBy($component->getRelationshipTitleColumnName())
                 ->toArray();
         });
 
@@ -476,7 +480,7 @@ class Select extends Field
 
             $relationship = $component->getRelationship();
 
-            $relationshipQuery = $relationship->getRelated()->query()->orderBy($component->getRelationshipTitleColumnName());
+            $relationshipQuery = $relationship->getRelated()->query();
 
             if ($callback) {
                 $relationshipQuery = $component->evaluate($callback, [
@@ -496,7 +500,9 @@ class Select extends Field
             }
 
             return $relationshipQuery
+                ->get()
                 ->pluck($component->getRelationshipTitleColumnName(), $keyName)
+                ->sortBy($component->getRelationshipTitleColumnName())
                 ->toArray();
         });
 


### PR DESCRIPTION
This change allows you to work with nested relationships, for example:

There are three models:
```
Post
 - id
 - category_id
 - ...
Category
 - id
 - slug
 - ...
CategoryTranslation
 - id
 - category_id
 - title
 - locale
 - ...
```

This does not affect users using this method.

My usage examle:

```php
Forms\Components\Select::make('category_id')
	->label('Category')
	->required()
	->searchable()
	->relationship('category', 'title', function (Builder $query, ?string $search, ?string $searchOperator) {
	    if (blank($search) && blank($searchOperator)) {
	        return $query->withTranslation();
	    } else {
	        return $query->whereTranslation('title', "%{$search}%", null, 'whereHas', $searchOperator);
	    }
	})
	->createOptionForm([
	    Forms\Components\TextInput::make('title')
	])
```