### PR TITLE
add component context to afterStateUpdated

### DIFF
--- a/src/Components/Concerns/HasState.php
+++ b/src/Components/Concerns/HasState.php
@@ -107,6 +107,7 @@ trait HasState
     protected function callAfterStateUpdatedHook(Closure $hook): void
     {
         $this->evaluate($hook, [
+            'component' => $this,
             'old' => $this->getOldState(),
         ]);
     }


### PR DESCRIPTION
Hey,

I'm trying to make afterStateUpdated compatible with my plugin for translations.

https://github.com/mvenghaus/filament-plugin-translatable-inline

There I clone the base component to have different fields. Doing this the context gets lost. In the callback I don't know which component this callback belongs to.

It's only a litte change :)

Regards
Marcus