### PR TITLE
Fix Call to a member function class() on array 

### DIFF
--- a/resources/views/components/builder.blade.php
+++ b/resources/views/components/builder.blade.php
@@ -120,7 +120,7 @@
                         x-on:expand="isCollapsed = false"
                         x-sortable-item="{{ $itemKey }}"
                         {{
-                            $item->getParentComponent()->getExtraAttributes()
+                            $item->getParentComponent()->getExtraAttributeBag()
                                 ->class(['fi-fo-builder-item'])
                         }}
                         x-bind:class="{ 'fi-collapsed': isCollapsed }"


### PR DESCRIPTION
Get collection when using ->class()

Fixes
Call to a member function class() on array 
![afbeelding](https://github.com/user-attachments/assets/c0d55663-9392-4c87-9c6e-7c2e054081e1)
